### PR TITLE
Add prompt decorator helper

### DIFF
--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -520,7 +520,7 @@ await client.deleteSession(session.sessionId);
 The HTTP server uses the same configuration system as the CLI:
 
 - **Config Files**: `~/.codex/config.json` or `~/.codex/config.yaml`
-- **Environment Variables**: `OPENAI_API_KEY`, etc.
+- **Environment Variables**: `OPENAI_API_KEY`, `PROMPT_DECORATOR_URL`, etc.
 - **Project Docs**: `AGENTS.md` files are loaded and used
 - **Provider Support**: All CLI providers are supported
 

--- a/codex-cli/src/http-server.ts
+++ b/codex-cli/src/http-server.ts
@@ -9,6 +9,7 @@ import { AutoApprovalMode } from "./utils/auto-approval-mode.js";
 import { ReviewDecision } from "./utils/agent/review.js";
 import { loadConfig } from "./utils/config.js";
 import { createInputItem } from "./utils/input-utils.js";
+import { decoratePrompt } from "./utils/decorate-prompt.js";
 import { log } from "./utils/logger/log.js";
 import express from "express";
 import { randomUUID } from "crypto";
@@ -243,8 +244,9 @@ export class CodexHttpServer {
         return;
       }
 
-      // Create input item from message and images
-      const inputItem = await createInputItem(message, images);
+      // Decorate prompt before creating input item
+      const decorated = await decoratePrompt(message);
+      const inputItem = await createInputItem(decorated, images);
       
       // Get current message count to track new messages
       const initialMessageCount = session.messages.length;

--- a/codex-cli/src/utils/decorate-prompt.ts
+++ b/codex-cli/src/utils/decorate-prompt.ts
@@ -1,0 +1,24 @@
+export async function decoratePrompt(text: string): Promise<string> {
+  const url = process.env.PROMPT_DECORATOR_URL;
+  if (!url) {
+    return text;
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: text }),
+    });
+
+    if (!res.ok) {
+      return text;
+    }
+
+    const data = (await res.json()) as { prompt?: string; decorated?: string };
+    const decorated = data.prompt ?? data.decorated;
+    return typeof decorated === "string" ? decorated : text;
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- support remote prompt decoration via `decoratePrompt`
- use decorated prompt when sending a message
- document `PROMPT_DECORATOR_URL`

## Testing
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*


------
https://chatgpt.com/codex/tasks/task_e_68483f25503c83329bcd58d59ae08e22